### PR TITLE
feat: グループ管理と支出編集フローをAPI/画面に統合

### DIFF
--- a/prisma/migrations/20260227150405_core_features/migration.sql
+++ b/prisma/migrations/20260227150405_core_features/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "expense_shares" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "expense_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "percent" REAL NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "expense_shares_expense_id_fkey" FOREIGN KEY ("expense_id") REFERENCES "expenses" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "expense_shares_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "settlements" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "group_id" TEXT NOT NULL,
+    "created_by_id" TEXT NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "settlements_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "settlements_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "settlement_transfers" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "settlement_id" TEXT NOT NULL,
+    "from_user_id" TEXT NOT NULL,
+    "to_user_id" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "settlement_transfers_settlement_id_fkey" FOREIGN KEY ("settlement_id") REFERENCES "settlements" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "settlement_transfers_from_user_id_fkey" FOREIGN KEY ("from_user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "settlement_transfers_to_user_id_fkey" FOREIGN KEY ("to_user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_group_members" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "user_id" TEXT NOT NULL,
+    "group_id" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'MEMBER',
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "group_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "group_members_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_group_members" ("created_at", "group_id", "id", "user_id") SELECT "created_at", "group_id", "id", "user_id" FROM "group_members";
+DROP TABLE "group_members";
+ALTER TABLE "new_group_members" RENAME TO "group_members";
+CREATE UNIQUE INDEX "group_members_user_id_group_id_key" ON "group_members"("user_id", "group_id");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "expense_shares_expense_id_user_id_key" ON "expense_shares"("expense_id", "user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,12 @@ datasource db {
   provider = "sqlite"
 }
 
+enum GroupRole {
+  OWNER
+  ADMIN
+  MEMBER
+}
+
 model User {
   id           String   @id @default(cuid())
   name         String
@@ -22,6 +28,7 @@ model User {
 
   groups   GroupMember[]
   expenses Expense[]
+  shares   ExpenseShare[]
 
   @@map("users")
 }
@@ -43,6 +50,7 @@ model GroupMember {
   id        String   @id @default(cuid())
   userId    String   @map("user_id")
   groupId   String   @map("group_id")
+  role      GroupRole @default(MEMBER)
   createdAt DateTime @default(now()) @map("created_at")
 
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -64,6 +72,21 @@ model Expense {
 
   group  Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
   member User  @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  shares ExpenseShare[]
 
   @@map("expenses")
+}
+
+model ExpenseShare {
+  id        String   @id @default(cuid())
+  expenseId String   @map("expense_id")
+  userId    String   @map("user_id")
+  percent   Float
+  createdAt DateTime @default(now()) @map("created_at")
+
+  expense Expense @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([expenseId, userId])
+  @@map("expense_shares")
 }

--- a/src/app/api/groups/[groupId]/expenses/[expenseId]/route.ts
+++ b/src/app/api/groups/[groupId]/expenses/[expenseId]/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError, ExpenseRecord } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { assertGroupMember, assertGroupRole, requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; expenseId: string }> }
+) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId, expenseId } = await params;
+    await assertGroupMember(groupId, userId);
+    const body = await req.json().catch(() => null);
+    if (!body) {
+      return NextResponse.json<ApiError>(
+        { error: "リクエストボディが不正です" },
+        { status: 400 }
+      );
+    }
+
+    const current = await prisma.expense.findUnique({
+      where: { id: expenseId },
+      include: { shares: true },
+    });
+    if (!current || current.groupId !== groupId) {
+      return NextResponse.json<ApiError>(
+        { error: "支出が見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    if (current.memberId !== userId) {
+      await assertGroupRole(groupId, userId, [GroupRole.OWNER, GroupRole.ADMIN]);
+    }
+
+    const shares = Array.isArray(body.shares) ? body.shares : null;
+    const updated = await prisma.expense.update({
+      where: { id: expenseId },
+      data: {
+        ...(body.category !== undefined && { category: body.category }),
+        ...(body.amount !== undefined && { amount: Number(body.amount) }),
+        ...(body.memo !== undefined && { memo: body.memo }),
+        ...(body.memberId !== undefined && { memberId: body.memberId }),
+        ...(shares && {
+          shares: {
+            deleteMany: {},
+            create: shares.map((s: { userId: string; percent: number }) => ({
+              userId: s.userId,
+              percent: Number(s.percent),
+            })),
+          },
+        }),
+      },
+      include: {
+        member: { select: { id: true, name: true } },
+        shares: { include: { user: { select: { id: true, name: true } } } },
+      },
+    });
+
+    const result: ExpenseRecord = {
+      id: updated.id,
+      category: updated.category as ExpenseRecord["category"],
+      amount: updated.amount,
+      memberId: updated.member.id,
+      memberName: updated.member.name,
+      memo: updated.memo ?? undefined,
+      date: updated.date.toISOString(),
+      shares: updated.shares.map((s) => ({
+        userId: s.user.id,
+        userName: s.user.name,
+        percent: s.percent,
+      })),
+    };
+    return NextResponse.json<ExpenseRecord>(result);
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "支出を編集する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "支出編集に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; expenseId: string }> }
+) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId, expenseId } = await params;
+    await assertGroupMember(groupId, userId);
+
+    const expense = await prisma.expense.findUnique({ where: { id: expenseId } });
+    if (!expense || expense.groupId !== groupId) {
+      return NextResponse.json<ApiError>(
+        { error: "支出が見つかりません" },
+        { status: 404 }
+      );
+    }
+    if (expense.memberId !== userId) {
+      await assertGroupRole(groupId, userId, [GroupRole.OWNER, GroupRole.ADMIN]);
+    }
+    await prisma.expense.delete({ where: { id: expenseId } });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "支出を削除する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "支出削除に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/groups/[groupId]/expenses/route.ts
+++ b/src/app/api/groups/[groupId]/expenses/route.ts
@@ -1,42 +1,61 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { ExpenseRecord, ApiError } from "@/types";
 import { prisma } from "@/lib/prisma";
-import { getAuthUserId } from "@/lib/auth";
+import { assertGroupMember, requireAuthUserId } from "@/lib/auth";
 
 /** GET /api/groups/[groupId]/expenses - 支出一覧取得 */
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ groupId: string }> }
 ) {
-  const userId = await getAuthUserId(req);
-  if (!userId) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupMember(groupId, userId);
+
+    const expenses = await prisma.expense.findMany({
+      where: { groupId },
+      include: {
+        member: { select: { id: true, name: true } },
+        shares: {
+          include: { user: { select: { id: true, name: true } } },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+      orderBy: { date: "desc" },
+    });
+
+    const result: ExpenseRecord[] = expenses.map((e) => ({
+      id: e.id,
+      category: e.category as ExpenseRecord["category"],
+      amount: e.amount,
+      memberId: e.member.id,
+      memberName: e.member.name,
+      memo: e.memo ?? undefined,
+      date: e.date.toISOString(),
+      shares: e.shares.map((s) => ({
+        userId: s.user.id,
+        userName: s.user.name,
+        percent: s.percent,
+      })),
+    }));
+
+    return NextResponse.json<ExpenseRecord[]>(result);
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "このグループの支出を閲覧する権限がありません" },
+        { status: 403 }
+      );
+    }
     return NextResponse.json<ApiError>(
-      { error: "認証が必要です" },
-      { status: 401 }
+      { error: "支出一覧取得に失敗しました" },
+      { status: 500 }
     );
   }
-
-  const { groupId } = await params;
-
-  const expenses = await prisma.expense.findMany({
-    where: { groupId },
-    include: {
-      member: { select: { id: true, name: true } },
-    },
-    orderBy: { date: "desc" },
-  });
-
-  const result: ExpenseRecord[] = expenses.map((e) => ({
-    id: e.id,
-    category: e.category as ExpenseRecord["category"],
-    amount: e.amount,
-    memberId: e.member.id,
-    memberName: e.member.name,
-    memo: e.memo ?? undefined,
-    date: e.date.toISOString(),
-  }));
-
-  return NextResponse.json<ExpenseRecord[]>(result);
 }
 
 /** POST /api/groups/[groupId]/expenses - 支出登録 */
@@ -44,47 +63,102 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ groupId: string }> }
 ) {
-  const userId = await getAuthUserId(req);
-  if (!userId) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupMember(groupId, userId);
+    const body = await req.json().catch(() => null);
+
+    if (!body || !body.category || !body.amount) {
+      return NextResponse.json<ApiError>(
+        { error: "カテゴリと金額は必須です" },
+        { status: 400 }
+      );
+    }
+
+    const members = await prisma.groupMember.findMany({
+      where: { groupId },
+      select: { userId: true },
+    });
+    const memberIds = new Set(members.map((m) => m.userId));
+    const incomingShares: { userId: string; percent: number }[] =
+      Array.isArray(body.shares) && body.shares.length > 0
+        ? body.shares
+        : members.map((m) => ({ userId: m.userId, percent: 100 / members.length }));
+
+    const percentTotal = incomingShares.reduce((sum, s) => sum + Number(s.percent || 0), 0);
+    if (Math.abs(percentTotal - 100) > 0.01) {
+      return NextResponse.json<ApiError>(
+        { error: "配分比率の合計は100%にしてください" },
+        { status: 400 }
+      );
+    }
+    if (incomingShares.some((s) => !memberIds.has(s.userId) || s.percent <= 0)) {
+      return NextResponse.json<ApiError>(
+        { error: "配分比率に不正なメンバーまたは値が含まれています" },
+        { status: 400 }
+      );
+    }
+    const payerId = body.memberId ?? userId;
+    if (!memberIds.has(payerId)) {
+      return NextResponse.json<ApiError>(
+        { error: "支払いメンバーがグループに存在しません" },
+        { status: 400 }
+      );
+    }
+
+    const expense = await prisma.expense.create({
+      data: {
+        groupId,
+        memberId: payerId,
+        category: body.category,
+        amount: body.amount,
+        memo: body.memo ?? null,
+        date: new Date(),
+        shares: {
+          create: incomingShares.map((s) => ({
+            userId: s.userId,
+            percent: s.percent,
+          })),
+        },
+      },
+      include: {
+        member: { select: { id: true, name: true } },
+        shares: {
+          include: { user: { select: { id: true, name: true } } },
+        },
+      },
+    });
+
+    const result: ExpenseRecord = {
+      id: expense.id,
+      category: expense.category as ExpenseRecord["category"],
+      amount: expense.amount,
+      memberId: expense.member.id,
+      memberName: expense.member.name,
+      memo: expense.memo ?? undefined,
+      date: expense.date.toISOString(),
+      shares: expense.shares.map((s) => ({
+        userId: s.user.id,
+        userName: s.user.name,
+        percent: s.percent,
+      })),
+    };
+
+    return NextResponse.json<ExpenseRecord>(result, { status: 201 });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "このグループに支出を登録する権限がありません" },
+        { status: 403 }
+      );
+    }
     return NextResponse.json<ApiError>(
-      { error: "認証が必要です" },
-      { status: 401 }
+      { error: "支出登録に失敗しました" },
+      { status: 500 }
     );
   }
-
-  const { groupId } = await params;
-  const body = await req.json().catch(() => null);
-
-  if (!body || !body.category || !body.amount) {
-    return NextResponse.json<ApiError>(
-      { error: "カテゴリと金額は必須です" },
-      { status: 400 }
-    );
-  }
-
-  const expense = await prisma.expense.create({
-    data: {
-      groupId,
-      memberId: userId,
-      category: body.category,
-      amount: body.amount,
-      memo: body.memo ?? null,
-      date: new Date(),
-    },
-    include: {
-      member: { select: { id: true, name: true } },
-    },
-  });
-
-  const result: ExpenseRecord = {
-    id: expense.id,
-    category: expense.category as ExpenseRecord["category"],
-    amount: expense.amount,
-    memberId: expense.member.id,
-    memberName: expense.member.name,
-    memo: expense.memo ?? undefined,
-    date: expense.date.toISOString(),
-  };
-
-  return NextResponse.json<ExpenseRecord>(result, { status: 201 });
 }

--- a/src/app/api/groups/[groupId]/members/[userId]/route.ts
+++ b/src/app/api/groups/[groupId]/members/[userId]/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { assertGroupMember, assertGroupRole, requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; userId: string }> }
+) {
+  try {
+    const actorId = await requireAuthUserId(req);
+    const { groupId, userId } = await params;
+    const actor = await assertGroupMember(groupId, actorId);
+    const target = await prisma.groupMember.findUnique({
+      where: { userId_groupId: { userId, groupId } },
+    });
+
+    if (!target) {
+      return NextResponse.json<ApiError>(
+        { error: "対象メンバーが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    const isSelf = actorId === userId;
+    if (isSelf) {
+      if (actor.role === GroupRole.OWNER) {
+        const owners = await prisma.groupMember.count({
+          where: { groupId, role: GroupRole.OWNER },
+        });
+        if (owners <= 1) {
+          return NextResponse.json<ApiError>(
+            { error: "最後のOWNERは脱退できません" },
+            { status: 400 }
+          );
+        }
+      }
+    } else {
+      await assertGroupRole(groupId, actorId, [GroupRole.OWNER, GroupRole.ADMIN]);
+      if (target.role === GroupRole.OWNER && actor.role !== GroupRole.OWNER) {
+        return NextResponse.json<ApiError>(
+          { error: "OWNERを除外できるのはOWNERのみです" },
+          { status: 403 }
+        );
+      }
+    }
+
+    await prisma.groupMember.delete({
+      where: { userId_groupId: { userId, groupId } },
+    });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "メンバーを除外する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "メンバー除外に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/groups/[groupId]/members/route.ts
+++ b/src/app/api/groups/[groupId]/members/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { assertGroupRole, requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const actorId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupRole(groupId, actorId, [GroupRole.OWNER, GroupRole.ADMIN]);
+
+    const body = await req.json().catch(() => null);
+    if (!body?.email || typeof body.email !== "string") {
+      return NextResponse.json<ApiError>(
+        { error: "追加するユーザーのメールアドレスが必要です" },
+        { status: 400 }
+      );
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email: body.email.trim() },
+      select: { id: true, name: true, color: true, email: true },
+    });
+    if (!user) {
+      return NextResponse.json<ApiError>(
+        { error: "指定したメールアドレスのユーザーが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    const existing = await prisma.groupMember.findUnique({
+      where: { userId_groupId: { userId: user.id, groupId } },
+    });
+    if (existing) {
+      return NextResponse.json<ApiError>(
+        { error: "このユーザーは既にグループに参加しています" },
+        { status: 409 }
+      );
+    }
+
+    const member = await prisma.groupMember.create({
+      data: {
+        groupId,
+        userId: user.id,
+        role: GroupRole.MEMBER,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        id: user.id,
+        name: user.name,
+        color: user.color,
+        role: member.role,
+      },
+      { status: 201 }
+    );
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "メンバーを追加する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "メンバー追加に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/groups/[groupId]/route.ts
+++ b/src/app/api/groups/[groupId]/route.ts
@@ -1,51 +1,154 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { Group, ApiError } from "@/types";
 import { prisma } from "@/lib/prisma";
-import { getAuthUserId } from "@/lib/auth";
+import { requireAuthUserId, assertGroupMember, assertGroupRole } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
 
 /** GET /api/groups/[groupId] - グループ詳細取得 */
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ groupId: string }> }
 ) {
-  const userId = await getAuthUserId(req);
-  if (!userId) {
-    return NextResponse.json<ApiError>(
-      { error: "認証が必要です" },
-      { status: 401 }
-    );
-  }
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupMember(groupId, userId);
 
-  const { groupId } = await params;
-
-  const group = await prisma.group.findUnique({
-    where: { id: groupId },
-    include: {
-      members: {
-        include: {
-          user: { select: { id: true, name: true, color: true } },
+    const group = await prisma.group.findUnique({
+      where: { id: groupId },
+      include: {
+        members: {
+          include: {
+            user: { select: { id: true, name: true, color: true } },
+          },
         },
       },
-    },
-  });
+    });
 
-  if (!group) {
+    if (!group) {
+      return NextResponse.json<ApiError>(
+        { error: "グループが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    const result: Group = {
+      id: group.id,
+      name: group.name,
+      color: group.color,
+      members: group.members.map((m) => ({
+        id: m.user.id,
+        name: m.user.name,
+        color: m.user.color,
+        role: m.role,
+      })),
+    };
+    return NextResponse.json<Group>(result);
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "このグループにアクセスする権限がありません" },
+        { status: 403 }
+      );
+    }
     return NextResponse.json<ApiError>(
-      { error: "グループが見つかりません" },
-      { status: 404 }
+      { error: "グループ取得に失敗しました" },
+      { status: 500 }
     );
   }
+}
 
-  const result: Group = {
-    id: group.id,
-    name: group.name,
-    color: group.color,
-    members: group.members.map((m) => ({
-      id: m.user.id,
-      name: m.user.name,
-      color: m.user.color,
-    })),
-  };
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupRole(groupId, userId, [GroupRole.OWNER, GroupRole.ADMIN]);
 
-  return NextResponse.json<Group>(result);
+    const body = await req.json().catch(() => null);
+    if (!body) {
+      return NextResponse.json<ApiError>(
+        { error: "リクエストボディが不正です" },
+        { status: 400 }
+      );
+    }
+    const data: { name?: string; color?: string } = {};
+    if (typeof body.name === "string" && body.name.trim().length > 0) {
+      data.name = body.name.trim();
+    }
+    if (typeof body.color === "string" && /^#[0-9A-Fa-f]{6}$/.test(body.color)) {
+      data.color = body.color;
+    }
+    const group = await prisma.group.update({
+      where: { id: groupId },
+      data,
+      include: {
+        members: {
+          include: { user: { select: { id: true, name: true, color: true } } },
+        },
+      },
+    });
+
+    const result: Group = {
+      id: group.id,
+      name: group.name,
+      color: group.color,
+      members: group.members.map((m) => ({
+        id: m.user.id,
+        name: m.user.name,
+        color: m.user.color,
+        role: m.role,
+      })),
+    };
+    return NextResponse.json<Group>(result);
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "グループを編集する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "グループ編集に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupRole(groupId, userId, [GroupRole.OWNER]);
+    await prisma.group.delete({ where: { id: groupId } });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "グループを削除する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "グループ削除に失敗しました" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/groups/route.ts
+++ b/src/app/api/groups/route.ts
@@ -1,42 +1,105 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { Group, ApiError } from "@/types";
 import { prisma } from "@/lib/prisma";
-import { getAuthUserId } from "@/lib/auth";
+import { requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
 
 /** GET /api/groups - グループ一覧取得 */
 export async function GET(req: NextRequest) {
-  const userId = await getAuthUserId(req);
-  if (!userId) {
-    return NextResponse.json<ApiError>(
-      { error: "認証が必要です" },
-      { status: 401 }
-    );
-  }
-
-  const groups = await prisma.group.findMany({
-    where: {
-      members: { some: { userId } },
-    },
-    include: {
-      members: {
-        include: {
-          user: { select: { id: true, name: true, color: true } },
+  try {
+    const userId = await requireAuthUserId(req);
+    const groups = await prisma.group.findMany({
+      where: {
+        members: { some: { userId } },
+      },
+      include: {
+        members: {
+          include: {
+            user: { select: { id: true, name: true, color: true } },
+          },
         },
       },
-    },
-  });
+    });
 
-  // レスポンス形状を既存の Group 型に合わせて整形
-  const result: Group[] = groups.map((g) => ({
-    id: g.id,
-    name: g.name,
-    color: g.color,
-    members: g.members.map((m) => ({
-      id: m.user.id,
-      name: m.user.name,
-      color: m.user.color,
-    })),
-  }));
+    const result: Group[] = groups.map((g) => ({
+      id: g.id,
+      name: g.name,
+      color: g.color,
+      members: g.members.map((m) => ({
+        id: m.user.id,
+        name: m.user.name,
+        color: m.user.color,
+        role: m.role,
+      })),
+    }));
 
-  return NextResponse.json<Group[]>(result);
+    return NextResponse.json<Group[]>(result);
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "グループ一覧の取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const body = await req.json().catch(() => null);
+    if (!body?.name || typeof body.name !== "string") {
+      return NextResponse.json<ApiError>(
+        { error: "グループ名は必須です" },
+        { status: 400 }
+      );
+    }
+    const color =
+      typeof body.color === "string" && /^#[0-9A-Fa-f]{6}$/.test(body.color)
+        ? body.color
+        : "#c9a227";
+
+    const created = await prisma.group.create({
+      data: {
+        name: body.name.trim(),
+        color,
+        members: {
+          create: [{ userId, role: GroupRole.OWNER }],
+        },
+      },
+      include: {
+        members: {
+          include: { user: { select: { id: true, name: true, color: true } } },
+        },
+      },
+    });
+
+    const result: Group = {
+      id: created.id,
+      name: created.name,
+      color: created.color,
+      members: created.members.map((m) => ({
+        id: m.user.id,
+        name: m.user.name,
+        color: m.user.color,
+        role: m.role,
+      })),
+    };
+    return NextResponse.json<Group>(result, { status: 201 });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "グループ作成に失敗しました" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import ScreenContainer from "@/components/layout/ScreenContainer";
 import PageTransition from "@/components/layout/PageTransition";
 import BottomNav from "@/components/layout/BottomNav";
+import RouteLoading from "@/components/layout/RouteLoading";
 import Logo from "@/components/ui/Logo";
 import type { Group } from "@/types";
 import {
@@ -55,7 +57,7 @@ export default function DashboardPage() {
     setSelectedId(group.id);
   };
 
-  if (!isReady) return null;
+  if (!isReady) return <RouteLoading text="グループを読み込み中..." withBottomNav />;
 
   return (
     <ScreenContainer>
@@ -70,6 +72,15 @@ export default function DashboardPage() {
         <p className="text-sm text-[#7a756d] dark:text-[#9e9a93] w-full mt-1 mb-5">
           家計簿を共有するグループを選んでください
         </p>
+
+        <div className="w-full mb-4">
+          <Link
+            href="/groups/new"
+            className="inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white bg-[#c9a227] hover:brightness-105"
+          >
+            + グループ作成
+          </Link>
+        </div>
 
         <div className="flex flex-col gap-4 w-full">
           {groups.map((group) => {
@@ -143,6 +154,16 @@ export default function DashboardPage() {
                   <span className="text-xs text-[#9e9a93] dark:text-[#666360] ml-2">
                     {group.members.map((m) => m.name).join("・")}
                   </span>
+                </div>
+
+                <div className="mt-3 ml-14">
+                  <Link
+                    href={`/groups/${group.id}/settings`}
+                    className="text-xs text-[#7a756d] dark:text-[#9e9a93] underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    グループ設定
+                  </Link>
                 </div>
               </button>
             );

--- a/src/app/groups/[groupId]/settings/page.tsx
+++ b/src/app/groups/[groupId]/settings/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+import ScreenContainer from "@/components/layout/ScreenContainer";
+import PageTransition from "@/components/layout/PageTransition";
+import RouteLoading from "@/components/layout/RouteLoading";
+import TextInput from "@/components/ui/TextInput";
+import PrimaryButton from "@/components/ui/PrimaryButton";
+import type { Group } from "@/types";
+import {
+  ApiClientError,
+  addMember,
+  deleteGroup,
+  getGroup,
+  removeMember,
+  updateGroup,
+} from "@/lib/apiClient";
+
+export default function GroupSettingsPage() {
+  const router = useRouter();
+  const params = useParams<{ groupId: string }>();
+  const groupId = params.groupId;
+
+  const [group, setGroup] = useState<Group | null>(null);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState("#c9a227");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    getGroup(groupId)
+      .then((g) => {
+        setGroup(g);
+        setName(g.name);
+        setColor(g.color);
+      })
+      .catch(() => {
+        router.replace("/dashboard");
+      });
+  }, [groupId, router]);
+
+  const refresh = async () => {
+    const g = await getGroup(groupId);
+    setGroup(g);
+    setName(g.name);
+    setColor(g.color);
+  };
+
+  const handleSave = async () => {
+    setLoading(true);
+    try {
+      await updateGroup(groupId, { name, color });
+      toast.success("グループを更新しました");
+      await refresh();
+    } catch (e) {
+      toast.error(e instanceof ApiClientError ? e.message : "更新に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm("本当にグループを削除しますか？")) return;
+    try {
+      await deleteGroup(groupId);
+      toast.success("グループを削除しました");
+      router.push("/dashboard");
+    } catch (e) {
+      toast.error(e instanceof ApiClientError ? e.message : "削除に失敗しました");
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!inviteEmail.trim()) return;
+    try {
+      await addMember(groupId, inviteEmail.trim());
+      toast.success("メンバーを追加しました");
+      setInviteEmail("");
+      await refresh();
+    } catch (e) {
+      toast.error(e instanceof ApiClientError ? e.message : "メンバー追加に失敗しました");
+    }
+  };
+
+  const handleRemove = async (userId: string) => {
+    if (!confirm("このメンバーを除外しますか？")) return;
+    try {
+      await removeMember(groupId, userId);
+      toast.success("メンバーを除外しました");
+      await refresh();
+    } catch (e) {
+      toast.error(e instanceof ApiClientError ? e.message : "メンバー除外に失敗しました");
+    }
+  };
+
+  if (!group) return <RouteLoading text="グループ設定を読み込み中..." />;
+
+  return (
+    <ScreenContainer>
+      <PageTransition className="flex flex-col w-full gap-5">
+        <h1 className="text-2xl font-bold text-[#2d2a26] dark:text-[#eae7e1]">
+          グループ設定
+        </h1>
+        <TextInput label="グループ名" value={name} onChange={setName} />
+        <label className="w-full">
+          <div className="text-base font-medium text-[#4a4540] dark:text-[#c5c0b8] mb-2">
+            テーマカラー
+          </div>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-12 w-24 rounded-lg"
+          />
+        </label>
+        <PrimaryButton onClick={handleSave} loading={loading}>
+          保存
+        </PrimaryButton>
+
+        <div className="border-t border-[#e5e0d8] dark:border-[#333230] pt-5">
+          <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1] mb-2">
+            メンバー招待
+          </h2>
+          <TextInput
+            label="メールアドレス"
+            type="email"
+            value={inviteEmail}
+            onChange={setInviteEmail}
+            placeholder="example@mail.com"
+          />
+          <div className="mt-3">
+            <PrimaryButton onClick={handleInvite}>追加する</PrimaryButton>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1] mb-2">
+            メンバー一覧
+          </h2>
+          <div className="flex flex-col gap-2">
+            {group.members.map((m) => (
+              <div
+                key={m.id}
+                className="flex items-center justify-between rounded-xl p-3 border border-[#e5e0d8] dark:border-[#333230]"
+              >
+                <span className="text-sm text-[#2d2a26] dark:text-[#eae7e1]">
+                  {m.name} {m.role ? `(${m.role})` : ""}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(m.id)}
+                  className="text-xs text-red-500 underline"
+                >
+                  除外
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="w-full h-12 rounded-xl border border-red-400 text-red-500 font-semibold"
+        >
+          グループを削除
+        </button>
+      </PageTransition>
+    </ScreenContainer>
+  );
+}

--- a/src/app/groups/new/page.tsx
+++ b/src/app/groups/new/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+import ScreenContainer from "@/components/layout/ScreenContainer";
+import PageTransition from "@/components/layout/PageTransition";
+import TextInput from "@/components/ui/TextInput";
+import PrimaryButton from "@/components/ui/PrimaryButton";
+import { ApiClientError, createGroup, setSelectedGroupId } from "@/lib/apiClient";
+
+export default function NewGroupPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [color, setColor] = useState("#c9a227");
+  const [loading, setLoading] = useState(false);
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      toast.error("グループ名を入力してください");
+      return;
+    }
+    setLoading(true);
+    try {
+      const group = await createGroup({ name: name.trim(), color });
+      setSelectedGroupId(group.id);
+      toast.success("グループを作成しました");
+      router.push("/dashboard");
+    } catch (e) {
+      if (e instanceof ApiClientError) {
+        toast.error(e.message);
+      } else {
+        toast.error("グループ作成に失敗しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScreenContainer>
+      <PageTransition className="flex flex-col w-full gap-5">
+        <h1 className="text-2xl font-bold text-[#2d2a26] dark:text-[#eae7e1]">
+          グループ作成
+        </h1>
+        <TextInput
+          label="グループ名"
+          placeholder="例: 旅行メンバー"
+          value={name}
+          onChange={setName}
+        />
+        <label className="w-full">
+          <div className="text-base font-medium text-[#4a4540] dark:text-[#c5c0b8] mb-2">
+            テーマカラー
+          </div>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-12 w-24 rounded-lg"
+          />
+        </label>
+        <PrimaryButton onClick={handleCreate} loading={loading}>
+          作成する
+        </PrimaryButton>
+      </PageTransition>
+    </ScreenContainer>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import toast from "react-hot-toast";
 import ScreenContainer from "@/components/layout/ScreenContainer";
 import PageTransition from "@/components/layout/PageTransition";
 import BottomNav from "@/components/layout/BottomNav";
+import RouteLoading from "@/components/layout/RouteLoading";
 import TextInput from "@/components/ui/TextInput";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import type { UserProfile } from "@/types";
@@ -157,7 +159,7 @@ export default function ProfilePage() {
     router.push("/home");
   };
 
-  if (!isReady) return null;
+  if (!isReady) return <RouteLoading text="プロフィールを読み込み中..." withBottomNav />;
 
   return (
     <ScreenContainer>
@@ -176,7 +178,14 @@ export default function ProfilePage() {
           style={{ backgroundColor: avatarUrl ? undefined : color }}
         >
           {avatarUrl ? (
-            <img src={avatarUrl} alt="アバター" className="w-full h-full object-cover" />
+            <Image
+              src={avatarUrl}
+              alt="アバター"
+              fill
+              unoptimized
+              className="object-cover"
+              sizes="112px"
+            />
           ) : (
             <span className="flex items-center justify-center w-full h-full text-5xl font-bold text-white">
               {name ? name.charAt(0) : "?"}

--- a/src/components/layout/RouteLoading.tsx
+++ b/src/components/layout/RouteLoading.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import ScreenContainer from "@/components/layout/ScreenContainer";
+import PageTransition from "@/components/layout/PageTransition";
+import BottomNav from "@/components/layout/BottomNav";
+
+type RouteLoadingProps = {
+  text?: string;
+  withBottomNav?: boolean;
+};
+
+export default function RouteLoading({
+  text = "読み込み中...",
+  withBottomNav = false,
+}: RouteLoadingProps) {
+  return (
+    <ScreenContainer>
+      <PageTransition className="flex flex-col items-center justify-center w-full flex-1 pb-20">
+        <div className="w-8 h-8 rounded-full border-2 border-[#e5e0d8] border-t-[#c9a227] animate-spin" />
+        <p className="mt-3 text-sm text-[#7a756d] dark:text-[#9e9a93]">{text}</p>
+      </PageTransition>
+      {withBottomNav && <BottomNav />}
+    </ScreenContainer>
+  );
+}

--- a/src/components/ui/ExpensePieChart.tsx
+++ b/src/components/ui/ExpensePieChart.tsx
@@ -67,9 +67,15 @@ export default function ExpensePieChart({
   data = DEFAULT_DATA,
   size = 220,
 }: ExpensePieChartProps) {
+  const hasCustomData = data !== DEFAULT_DATA;
   const filteredData = data.filter((d) => d.value > 0);
-  const chartData = filteredData.length > 0 ? filteredData : DEFAULT_DATA;
-  const total = chartData.reduce((s, d) => s + d.value, 0);
+  const total = data.reduce((s, d) => s + d.value, 0);
+  const chartData =
+    filteredData.length > 0
+      ? filteredData
+      : hasCustomData
+        ? [{ name: "その他" as CategoryName, value: 1, color: "#e5e0d8" }]
+        : DEFAULT_DATA;
 
   return (
     <div className="flex flex-col items-center w-full">
@@ -132,7 +138,7 @@ export default function ExpensePieChart({
           </RechartsPieChart>
         </ResponsiveContainer>
       </div>
-      <ChartLegend data={chartData} />
+      <ChartLegend data={hasCustomData ? data : chartData} />
     </div>
   );
 }

--- a/src/components/ui/GenreSelect.tsx
+++ b/src/components/ui/GenreSelect.tsx
@@ -5,9 +5,9 @@ type GenreSelectProps = {
 
 const GENRE_OPTIONS = [
   { value: "", label: "ジャンル" },
-  { value: "交通費", label: "交通費" },
+  { value: "交通", label: "交通費" },
   { value: "食費", label: "食費" },
-  { value: "住居費", label: "住居費" },
+  { value: "住居", label: "住居費" },
   { value: "貯金", label: "貯金" },
   { value: "娯楽", label: "娯楽" },
   { value: "その他", label: "その他" },

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -12,6 +12,7 @@ import type {
   Group,
   ExpenseRecord,
   CategoryName,
+  ExpenseShare,
 } from "@/types";
 
 /* ========== トークン管理 ========== */
@@ -185,6 +186,54 @@ export async function getGroup(groupId: string): Promise<Group> {
   return apiFetch<Group>(`/api/groups/${groupId}`);
 }
 
+export async function createGroup(input: {
+  name: string;
+  color?: string;
+}): Promise<Group> {
+  return apiFetch<Group>("/api/groups", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateGroup(
+  groupId: string,
+  input: { name?: string; color?: string }
+): Promise<Group> {
+  return apiFetch<Group>(`/api/groups/${groupId}`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteGroup(groupId: string): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/api/groups/${groupId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function addMember(
+  groupId: string,
+  email: string
+): Promise<{ id: string; name: string; color: string; role: string }> {
+  return apiFetch<{ id: string; name: string; color: string; role: string }>(
+    `/api/groups/${groupId}/members`,
+    {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    }
+  );
+}
+
+export async function removeMember(
+  groupId: string,
+  userId: string
+): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/api/groups/${groupId}/members/${userId}`, {
+    method: "DELETE",
+  });
+}
+
 /* ========== 支出 API ========== */
 
 export async function getExpenses(groupId: string): Promise<ExpenseRecord[]> {
@@ -199,11 +248,38 @@ export async function createExpense(
     memberId?: string;
     memberName?: string;
     memo?: string;
+    shares?: ExpenseShare[];
   }
 ): Promise<ExpenseRecord> {
   return apiFetch<ExpenseRecord>(`/api/groups/${groupId}/expenses`, {
     method: "POST",
     body: JSON.stringify(expense),
+  });
+}
+
+export async function updateExpense(
+  groupId: string,
+  expenseId: string,
+  expense: Partial<{
+    category: CategoryName;
+    amount: number;
+    memberId: string;
+    memo: string;
+    shares: ExpenseShare[];
+  }>
+): Promise<ExpenseRecord> {
+  return apiFetch<ExpenseRecord>(`/api/groups/${groupId}/expenses/${expenseId}`, {
+    method: "PUT",
+    body: JSON.stringify(expense),
+  });
+}
+
+export async function deleteExpense(
+  groupId: string,
+  expenseId: string
+): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/api/groups/${groupId}/expenses/${expenseId}`, {
+    method: "DELETE",
   });
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,7 @@
 import { SignJWT, jwtVerify } from "jose";
 import type { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { GroupRole } from "@/generated/prisma/client";
 
 const SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET ?? "dev-secret-change-in-production"
@@ -31,4 +33,40 @@ export async function getAuthUserId(req: NextRequest): Promise<string | null> {
   if (!auth?.startsWith("Bearer ")) return null;
   const token = auth.slice(7);
   return verifyToken(token);
+}
+
+export async function requireAuthUserId(req: NextRequest): Promise<string> {
+  const userId = await getAuthUserId(req);
+  if (!userId) {
+    throw new Error("UNAUTHORIZED");
+  }
+  return userId;
+}
+
+export async function getGroupMember(groupId: string, userId: string) {
+  return prisma.groupMember.findUnique({
+    where: {
+      userId_groupId: { userId, groupId },
+    },
+  });
+}
+
+export async function assertGroupMember(groupId: string, userId: string) {
+  const member = await getGroupMember(groupId, userId);
+  if (!member) {
+    throw new Error("FORBIDDEN");
+  }
+  return member;
+}
+
+export async function assertGroupRole(
+  groupId: string,
+  userId: string,
+  allowedRoles: GroupRole[]
+) {
+  const member = await assertGroupMember(groupId, userId);
+  if (!allowedRoles.includes(member.role)) {
+    throw new Error("FORBIDDEN");
+  }
+  return member;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 /** カテゴリ名 */
 export type CategoryName = "貯金" | "住居" | "交通" | "食費" | "娯楽" | "その他";
+export type GroupRole = "OWNER" | "ADMIN" | "MEMBER";
 
 /** グループメンバーの型 */
 export type GroupMember = {
@@ -7,6 +8,7 @@ export type GroupMember = {
   name: string;
   /** アバターの色（背景色として使用） */
   color: string;
+  role?: GroupRole;
 };
 
 /** グループの型 */
@@ -43,6 +45,19 @@ export type ExpenseRecord = {
   memo?: string;
   /** 登録日時 ISO 文字列 */
   date: string;
+  shares?: ExpenseShare[];
+};
+
+export type ExpenseShare = {
+  userId: string;
+  percent: number;
+  userName?: string;
+};
+
+export type ExpenseWithShares = {
+  amount: number;
+  memberId: string;
+  shares: ExpenseShare[];
 };
 
 /** ログインレスポンス */


### PR DESCRIPTION
グループ作成・編集・削除とメンバー追加/除外、支出の編集/削除とカテゴリ集計反映を実装し、履歴編集導線とローディング表示を整えて操作中の途切れを減らす。精算機能は要望に合わせて除外し、現在の運用フローに合わせた構成へ整理する。

Made-with: Cursor