### PR TITLE
feat: 割り勘精算ロジックを実装

### DIFF
--- a/src/app/api/groups/[groupId]/settlement/route.ts
+++ b/src/app/api/groups/[groupId]/settlement/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError, SettlementResult, GroupMember, ExpenseRecord } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { assertGroupMember, requireAuthUserId } from "@/lib/auth";
+import { calculateSettlement } from "@/lib/settlement";
+
+/** GET /api/groups/[groupId]/settlement - 精算計算結果取得 */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupMember(groupId, userId);
+
+    const [groupData, expenses] = await Promise.all([
+      prisma.group.findUnique({
+        where: { id: groupId },
+        include: {
+          members: {
+            include: { user: { select: { id: true, name: true, color: true, avatarUrl: true } } },
+          },
+        },
+      }),
+      prisma.expense.findMany({
+        where: { groupId },
+        include: {
+          shares: true,
+        },
+      }),
+    ]);
+
+    if (!groupData) {
+      return NextResponse.json<ApiError>({ error: "グループが見つかりません" }, { status: 404 });
+    }
+
+    const members: GroupMember[] = groupData.members.map((m) => ({
+      id: m.user.id,
+      name: m.user.name,
+      color: m.user.color,
+      avatarUrl: m.user.avatarUrl ?? undefined,
+    }));
+
+    const expenseRecords: ExpenseRecord[] = expenses.map((e) => ({
+      id: e.id,
+      category: e.category as ExpenseRecord["category"],
+      amount: e.amount,
+      memberId: e.memberId,
+      memberName: "",
+      date: e.date.toISOString(),
+      shares: e.shares.map((s) => ({ userId: s.userId, percent: s.percent })),
+    }));
+
+    const result = calculateSettlement(members, expenseRecords);
+
+    return NextResponse.json<SettlementResult>(result);
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "このグループの精算情報を閲覧する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "精算計算に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/expense/history/page.tsx
+++ b/src/app/expense/history/page.tsx
@@ -307,6 +307,14 @@ export default function HistoryPage() {
 
         <SummaryCard expenses={expenses} group={group} />
 
+        <button
+          type="button"
+          onClick={() => router.push(`/groups/${groupId}/settlement`)}
+          className="w-full mt-3 h-11 rounded-xl border border-[#c9a227] text-[#c9a227] font-semibold text-sm"
+        >
+          精算を確認 →
+        </button>
+
         <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1] mt-6 mb-2">
           支出履歴
         </h2>

--- a/src/app/groups/[groupId]/settlement/page.tsx
+++ b/src/app/groups/[groupId]/settlement/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import ScreenContainer from "@/components/layout/ScreenContainer";
+import PageTransition from "@/components/layout/PageTransition";
+import BottomNav from "@/components/layout/BottomNav";
+import RouteLoading from "@/components/layout/RouteLoading";
+import GroupAvatar from "@/components/ui/GroupAvatar";
+import type { Group, SettlementResult } from "@/types";
+import { getGroup, getSettlement, isAuthenticated } from "@/lib/apiClient";
+
+function UserAvatar({
+  name,
+  color,
+  avatarUrl,
+  size = 40,
+}: {
+  name: string;
+  color: string;
+  avatarUrl?: string;
+  size?: number;
+}) {
+  return (
+    <div
+      className="rounded-full flex items-center justify-center shrink-0 overflow-hidden"
+      style={{ width: size, height: size, backgroundColor: color }}
+    >
+      {avatarUrl ? (
+        <Image src={avatarUrl} alt={name} width={size} height={size} unoptimized className="object-cover" />
+      ) : (
+        <span className="text-white font-bold" style={{ fontSize: size * 0.4 }}>
+          {name.slice(0, 1)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function SettlementPage() {
+  const router = useRouter();
+  const params = useParams<{ groupId: string }>();
+  const groupId = params.groupId;
+
+  const [isReady, setIsReady] = useState(false);
+  const [group, setGroup] = useState<Group | null>(null);
+  const [settlement, setSettlement] = useState<SettlementResult | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!isAuthenticated()) {
+      router.replace("/login");
+      return;
+    }
+
+    Promise.all([getGroup(groupId), getSettlement(groupId)])
+      .then(([g, s]) => {
+        setGroup(g);
+        setSettlement(s);
+        setIsReady(true);
+      })
+      .catch(() => {
+        router.replace("/dashboard");
+      });
+  }, [groupId, router]);
+
+  if (!isReady || !group || !settlement) {
+    return <RouteLoading text="精算を計算中..." withBottomNav />;
+  }
+
+  return (
+    <ScreenContainer>
+      <PageTransition className="flex flex-col w-full flex-1 pb-20">
+        <p
+          className="text-4xl text-[#2d2a26] dark:text-[#eae7e1] pb-4 text-center"
+          style={{ fontFamily: "var(--font-dancing-script), cursive" }}
+        >
+          Share Wallet
+        </p>
+
+        <div className="flex items-center gap-2 mb-4">
+          <GroupAvatar name={group.name} color={group.color} iconUrl={group.iconUrl} size={32} className="rounded-full" />
+          <span className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1]">
+            {group.name}
+          </span>
+        </div>
+
+        {/* サマリーカード */}
+        <div
+          className="w-full rounded-2xl p-5 text-white shadow-lg mb-6"
+          style={{
+            background: "linear-gradient(135deg, #d4a320 0%, #e8c547 50%, #c9a227 100%)",
+          }}
+        >
+          <p className="text-sm font-medium opacity-90">全期間の合計支出</p>
+          <p className="text-3xl font-bold mt-1 tabular-nums">
+            ¥{settlement.totalExpenseAmount.toLocaleString()}
+          </p>
+          <div className="flex items-center gap-6 mt-3 pt-3 border-t border-white/30">
+            <div>
+              <p className="text-xs opacity-80">件数</p>
+              <p className="text-lg font-bold tabular-nums">{settlement.expenseCount}件</p>
+            </div>
+            <div>
+              <p className="text-xs opacity-80">メンバー</p>
+              <p className="text-lg font-bold tabular-nums">{group.members.length}人</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 精算トランザクション */}
+        <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1] mb-3">
+          精算方法
+        </h2>
+
+        {settlement.transactions.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10 text-center">
+            <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center mb-3">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-8 h-8 text-green-500">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <p className="text-base font-semibold text-[#2d2a26] dark:text-[#eae7e1]">精算は不要です</p>
+            <p className="text-sm text-[#9e9a93] mt-1">全員の支払いが均等です</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 mb-6">
+            {settlement.transactions.map((tx, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-3 p-4 rounded-2xl bg-white dark:bg-[#1c1b19] shadow-sm border border-[#f0ece6] dark:border-[#262522]"
+              >
+                <UserAvatar name={tx.fromUserName} color={tx.fromUserColor} avatarUrl={tx.fromUserAvatarUrl} size={40} />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-[#2d2a26] dark:text-[#eae7e1] truncate">
+                    {tx.fromUserName}
+                  </p>
+                  <p className="text-xs text-[#9e9a93]">支払う</p>
+                </div>
+                <div className="flex flex-col items-center px-2">
+                  <p className="text-base font-bold text-[#c9a227] tabular-nums">
+                    ¥{tx.amount.toLocaleString()}
+                  </p>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-5 h-5 text-[#c9a227] mt-0.5">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0 text-right">
+                  <p className="text-sm font-semibold text-[#2d2a26] dark:text-[#eae7e1] truncate">
+                    {tx.toUserName}
+                  </p>
+                  <p className="text-xs text-[#9e9a93]">受け取る</p>
+                </div>
+                <UserAvatar name={tx.toUserName} color={tx.toUserColor} avatarUrl={tx.toUserAvatarUrl} size={40} />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 残高一覧 */}
+        <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1] mb-3">
+          残高内訳
+        </h2>
+
+        <div className="flex flex-col gap-2">
+          {settlement.memberBalances.map((mb) => (
+            <div
+              key={mb.userId}
+              className="flex items-center gap-3 p-3 rounded-xl bg-white dark:bg-[#1c1b19] border border-[#f0ece6] dark:border-[#262522]"
+            >
+              <UserAvatar name={mb.userName} color={mb.userColor} avatarUrl={mb.userAvatarUrl} size={36} />
+              <span className="flex-1 text-sm font-medium text-[#2d2a26] dark:text-[#eae7e1] truncate">
+                {mb.userName}
+              </span>
+              <span
+                className={[
+                  "text-sm font-bold tabular-nums",
+                  mb.balance > 0
+                    ? "text-green-500"
+                    : mb.balance < 0
+                    ? "text-red-500"
+                    : "text-[#9e9a93]",
+                ].join(" ")}
+              >
+                {mb.balance > 0 ? "+" : ""}
+                ¥{mb.balance.toLocaleString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      </PageTransition>
+
+      <BottomNav />
+    </ScreenContainer>
+  );
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -14,6 +14,7 @@ import type {
   CategoryName,
   ExpenseShare,
   DashboardSummary,
+  SettlementResult,
 } from "@/types";
 
 /* ========== トークン管理 ========== */
@@ -287,6 +288,10 @@ export async function deleteExpense(
   return apiFetch<{ ok: boolean }>(`/api/groups/${groupId}/expenses/${expenseId}`, {
     method: "DELETE",
   });
+}
+
+export async function getSettlement(groupId: string): Promise<SettlementResult> {
+  return apiFetch<SettlementResult>(`/api/groups/${groupId}/settlement`);
 }
 
 export { ApiClientError };

--- a/src/lib/settlement.ts
+++ b/src/lib/settlement.ts
@@ -1,0 +1,85 @@
+import type {
+  GroupMember,
+  ExpenseRecord,
+  MemberBalance,
+  SettlementTransaction,
+  SettlementResult,
+} from "@/types";
+
+export function calculateSettlement(
+  members: GroupMember[],
+  expenses: ExpenseRecord[]
+): SettlementResult {
+  const balanceMap = new Map<string, number>();
+  for (const member of members) balanceMap.set(member.id, 0);
+
+  for (const { amount, memberId, shares } of expenses) {
+    balanceMap.set(memberId, (balanceMap.get(memberId) ?? 0) + amount);
+
+    if (shares && shares.length > 0) {
+      for (const share of shares) {
+        const owed = amount * (share.percent / 100);
+        balanceMap.set(share.userId, (balanceMap.get(share.userId) ?? 0) - owed);
+      }
+    } else {
+      const equal = amount / members.length;
+      for (const m of members) {
+        balanceMap.set(m.id, (balanceMap.get(m.id) ?? 0) - equal);
+      }
+    }
+  }
+
+  const memberBalances: MemberBalance[] = members.map((m) => ({
+    userId: m.id,
+    userName: m.name,
+    userColor: m.color,
+    userAvatarUrl: m.avatarUrl,
+    balance: Math.round(balanceMap.get(m.id) ?? 0),
+  }));
+
+  return {
+    transactions: minimumCashFlow(memberBalances),
+    memberBalances,
+    totalExpenseAmount: expenses.reduce((s, e) => s + e.amount, 0),
+    expenseCount: expenses.length,
+  };
+}
+
+function minimumCashFlow(balances: MemberBalance[]): SettlementTransaction[] {
+  const creditors = balances
+    .filter((b) => b.balance > 0)
+    .map((b) => ({ ...b }))
+    .sort((a, b) => b.balance - a.balance);
+
+  const debtors = balances
+    .filter((b) => b.balance < 0)
+    .map((b) => ({ ...b, balance: -b.balance }))
+    .sort((a, b) => b.balance - a.balance);
+
+  const transactions: SettlementTransaction[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < creditors.length && j < debtors.length) {
+    const amount = Math.min(creditors[i].balance, debtors[j].balance);
+    if (amount > 0) {
+      transactions.push({
+        fromUserId: debtors[j].userId,
+        fromUserName: debtors[j].userName,
+        fromUserColor: debtors[j].userColor,
+        fromUserAvatarUrl: debtors[j].userAvatarUrl,
+        toUserId: creditors[i].userId,
+        toUserName: creditors[i].userName,
+        toUserColor: creditors[i].userColor,
+        toUserAvatarUrl: creditors[i].userAvatarUrl,
+        amount,
+      });
+    }
+    creditors[i].balance -= amount;
+    debtors[j].balance -= amount;
+    if (creditors[i].balance <= 0) i++;
+    if (debtors[j].balance <= 0) j++;
+  }
+
+  return transactions;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,34 @@ export type DashboardCategorySummary = {
   amount: number;
 };
 
+export type MemberBalance = {
+  userId: string;
+  userName: string;
+  userColor: string;
+  userAvatarUrl?: string;
+  /** 正: 受け取るべき金額、負: 支払うべき金額 */
+  balance: number;
+};
+
+export type SettlementTransaction = {
+  fromUserId: string;
+  fromUserName: string;
+  fromUserColor: string;
+  fromUserAvatarUrl?: string;
+  toUserId: string;
+  toUserName: string;
+  toUserColor: string;
+  toUserAvatarUrl?: string;
+  amount: number;
+};
+
+export type SettlementResult = {
+  transactions: SettlementTransaction[];
+  memberBalances: MemberBalance[];
+  totalExpenseAmount: number;
+  expenseCount: number;
+};
+
 export type DashboardSummary = {
   totalPersonalAmount: number;
   previousMonthTotalPersonalAmount: number;


### PR DESCRIPTION
## 概要
グループ内の全支出から「誰が誰にいくら払えばよいか」を計算し、最小回数の振込で精算できるトランザクション一覧を表示する機能を追加。

## 変更内容
- `src/lib/settlement.ts` を新規作成：残高計算 + Minimum Cash Flow アルゴリズムのピュア関数
- `src/app/api/groups/[groupId]/settlement/route.ts` を新規作成：精算結果を返す GET エンドポイント
- `src/app/groups/[groupId]/settlement/page.tsx` を新規作成：振込リスト・残高内訳を表示するページ
- `src/types/index.ts`：`MemberBalance` / `SettlementTransaction` / `SettlementResult` 型を追加
- `src/lib/apiClient.ts`：`getSettlement()` を追加
- `src/app/expense/history/page.tsx`：サマリーカード下に「精算を確認 →」ボタンを追加

## 背景・理由
支出の記録・割合（%）の保存は実装済みだったが、「最終的に誰がいくら払うか」を導出するロジックが存在しなかった。割り勘アプリとして精算フローは必須機能であるため追加した。

## 技術的な判断
**精算アルゴリズムに Minimum Cash Flow を採用**：単純に各ペア間の差分を計算する方式と比較し、振込回数を最小化できる。メンバー数が少ない家計簿アプリのユースケースでは O(n²) の貪欲法で十分。

**計算はサーバーサイド（API Route）で実施**：支出データはすでにサーバー側に存在するため、クライアントへの全件転送を避けてサーバーで計算する方が効率的かつ既存パターンと一貫している。

**精算は全期間対象**：月次フィルタをかけると「先月立て替えた分が今月の精算に反映されない」等の混乱が生じるため、グループ作成から現在までの全支出を対象とした。

## 動作確認
- [x] ローカルで動作確認済み
- [x] 既存機能に影響がないことを確認

## スクリーンショット（UIの変更がある場合）
<!-- 動作確認後に追加してください -->