### PR TITLE
feat: 招待リンク方式によるメンバー招待機能を実装

### DIFF
--- a/prisma/migrations/20260425170030_add_group_invitations/migration.sql
+++ b/prisma/migrations/20260425170030_add_group_invitations/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "InvitationStatus" AS ENUM ('ACTIVE', 'REVOKED');
+
+-- CreateTable
+CREATE TABLE "group_invitations" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "group_id" TEXT NOT NULL,
+    "created_by_id" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3),
+    "status" "InvitationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "group_invitations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "group_invitations_token_key" ON "group_invitations"("token");
+
+-- AddForeignKey
+ALTER TABLE "group_invitations" ADD CONSTRAINT "group_invitations_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group_invitations" ADD CONSTRAINT "group_invitations_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,11 @@ enum GroupRole {
   MEMBER
 }
 
+enum InvitationStatus {
+  ACTIVE
+  REVOKED
+}
+
 model User {
   id           String   @id @default(cuid())
   name         String
@@ -26,9 +31,10 @@ model User {
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 
-  groups   GroupMember[]
-  expenses Expense[]
-  shares   ExpenseShare[]
+  groups             GroupMember[]
+  expenses           Expense[]
+  shares             ExpenseShare[]
+  createdInvitations GroupInvitation[]
 
   @@map("users")
 }
@@ -41,8 +47,9 @@ model Group {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  members  GroupMember[]
-  expenses Expense[]
+  members     GroupMember[]
+  expenses    Expense[]
+  invitations GroupInvitation[]
 
   @@map("groups")
 }
@@ -90,4 +97,19 @@ model ExpenseShare {
 
   @@unique([expenseId, userId])
   @@map("expense_shares")
+}
+
+model GroupInvitation {
+  id          String           @id @default(cuid())
+  token       String           @unique
+  groupId     String           @map("group_id")
+  createdById String           @map("created_by_id")
+  expiresAt   DateTime?        @map("expires_at")
+  status      InvitationStatus @default(ACTIVE)
+  createdAt   DateTime         @default(now()) @map("created_at")
+
+  group     Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  createdBy User  @relation(fields: [createdById], references: [id], onDelete: Cascade)
+
+  @@map("group_invitations")
 }

--- a/src/app/api/groups/[groupId]/invitations/[invitationId]/route.ts
+++ b/src/app/api/groups/[groupId]/invitations/[invitationId]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { assertGroupRole, requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; invitationId: string }> }
+) {
+  try {
+    const actorId = await requireAuthUserId(req);
+    const { groupId, invitationId } = await params;
+    await assertGroupRole(groupId, actorId, [GroupRole.OWNER, GroupRole.ADMIN]);
+
+    const invitation = await prisma.groupInvitation.findFirst({
+      where: { id: invitationId, groupId },
+    });
+    if (!invitation) {
+      return NextResponse.json<ApiError>(
+        { error: "招待リンクが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    await prisma.groupInvitation.update({
+      where: { id: invitationId },
+      data: { status: "REVOKED" },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "招待リンクを無効化する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "招待リンクの無効化に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/groups/[groupId]/invitations/route.ts
+++ b/src/app/api/groups/[groupId]/invitations/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import type { ApiError } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { assertGroupRole, requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const actorId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupRole(groupId, actorId, [GroupRole.OWNER, GroupRole.ADMIN]);
+
+    const body = await req.json().catch(() => ({}));
+    const expiresInDays: number =
+      typeof body.expiresInDays === "number" && body.expiresInDays > 0
+        ? body.expiresInDays
+        : 7;
+
+    const token = randomBytes(16).toString("hex");
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
+
+    const invitation = await prisma.groupInvitation.create({
+      data: { token, groupId, createdById: actorId, expiresAt },
+    });
+
+    const baseUrl = req.headers.get("origin") ?? "";
+    return NextResponse.json(
+      {
+        id: invitation.id,
+        token: invitation.token,
+        url: `${baseUrl}/invite/${invitation.token}`,
+        expiresAt: invitation.expiresAt?.toISOString() ?? null,
+        createdAt: invitation.createdAt.toISOString(),
+        status: invitation.status,
+      },
+      { status: 201 }
+    );
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "招待リンクを作成する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "招待リンクの作成に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string }> }
+) {
+  try {
+    const actorId = await requireAuthUserId(req);
+    const { groupId } = await params;
+    await assertGroupRole(groupId, actorId, [GroupRole.OWNER, GroupRole.ADMIN]);
+
+    const invitations = await prisma.groupInvitation.findMany({
+      where: { groupId, status: "ACTIVE" },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const baseUrl = req.headers.get("origin") ?? "";
+    return NextResponse.json(
+      invitations.map((inv) => ({
+        id: inv.id,
+        token: inv.token,
+        url: `${baseUrl}/invite/${inv.token}`,
+        expiresAt: inv.expiresAt?.toISOString() ?? null,
+        createdAt: inv.createdAt.toISOString(),
+        status: inv.status,
+      }))
+    );
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    if (e instanceof Error && e.message === "FORBIDDEN") {
+      return NextResponse.json<ApiError>(
+        { error: "招待リンクを取得する権限がありません" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json<ApiError>(
+      { error: "招待リンクの取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/invite/[token]/accept/route.ts
+++ b/src/app/api/invite/[token]/accept/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError } from "@/types";
+import { prisma } from "@/lib/prisma";
+import { requireAuthUserId } from "@/lib/auth";
+import { GroupRole } from "@/generated/prisma/client";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const userId = await requireAuthUserId(req);
+    const { token } = await params;
+
+    const invitation = await prisma.groupInvitation.findUnique({
+      where: { token },
+      include: { group: { select: { id: true, name: true } } },
+    });
+
+    if (!invitation || invitation.status !== "ACTIVE") {
+      return NextResponse.json<ApiError>(
+        { error: "この招待リンクは無効です" },
+        { status: 404 }
+      );
+    }
+
+    if (invitation.expiresAt && invitation.expiresAt < new Date()) {
+      return NextResponse.json<ApiError>(
+        { error: "この招待リンクの有効期限が切れています" },
+        { status: 410 }
+      );
+    }
+
+    const existing = await prisma.groupMember.findUnique({
+      where: { userId_groupId: { userId, groupId: invitation.groupId } },
+    });
+
+    if (!existing) {
+      await prisma.groupMember.create({
+        data: { userId, groupId: invitation.groupId, role: GroupRole.MEMBER },
+      });
+    }
+
+    return NextResponse.json({
+      groupId: invitation.groupId,
+      groupName: invitation.group.name,
+    });
+  } catch (e) {
+    if (e instanceof Error && e.message === "UNAUTHORIZED") {
+      return NextResponse.json<ApiError>({ error: "認証が必要です" }, { status: 401 });
+    }
+    return NextResponse.json<ApiError>(
+      { error: "グループへの参加に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/invite/[token]/route.ts
+++ b/src/app/api/invite/[token]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ApiError } from "@/types";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const invitation = await prisma.groupInvitation.findUnique({
+    where: { token },
+    include: {
+      group: {
+        include: { _count: { select: { members: true } } },
+      },
+      createdBy: { select: { name: true } },
+    },
+  });
+
+  if (!invitation || invitation.status !== "ACTIVE") {
+    return NextResponse.json<ApiError>(
+      { error: "この招待リンクは無効です" },
+      { status: 404 }
+    );
+  }
+
+  if (invitation.expiresAt && invitation.expiresAt < new Date()) {
+    return NextResponse.json<ApiError>(
+      { error: "この招待リンクの有効期限が切れています" },
+      { status: 410 }
+    );
+  }
+
+  return NextResponse.json({
+    groupId: invitation.groupId,
+    groupName: invitation.group.name,
+    groupColor: invitation.group.color,
+    groupIconUrl: invitation.group.iconUrl ?? undefined,
+    memberCount: invitation.group._count.members,
+    createdByName: invitation.createdBy.name,
+    expiresAt: invitation.expiresAt?.toISOString() ?? null,
+  });
+}

--- a/src/app/groups/[groupId]/settings/page.tsx
+++ b/src/app/groups/[groupId]/settings/page.tsx
@@ -11,13 +11,16 @@ import TextInput from "@/components/ui/TextInput";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import ColorPalette from "@/components/ui/ColorPalette";
 import GroupAvatar from "@/components/ui/GroupAvatar";
-import type { Group } from "@/types";
+import type { Group, GroupInvitation } from "@/types";
 import {
   ApiClientError,
   addMember,
+  createInvitation,
   deleteGroup,
   getGroup,
+  getInvitations,
   removeMember,
+  revokeInvitation,
   updateGroup,
 } from "@/lib/apiClient";
 
@@ -33,14 +36,17 @@ export default function GroupSettingsPage() {
   const [iconUrl, setIconUrl] = useState<string | undefined>(undefined);
   const [inviteEmail, setInviteEmail] = useState("");
   const [loading, setLoading] = useState(false);
+  const [invitations, setInvitations] = useState<GroupInvitation[]>([]);
+  const [newInviteUrl, setNewInviteUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    getGroup(groupId)
-      .then((g) => {
+    Promise.all([getGroup(groupId), getInvitations(groupId)])
+      .then(([g, invs]) => {
         setGroup(g);
         setName(g.name);
         setColor(g.color);
         setIconUrl(g.iconUrl);
+        setInvitations(invs);
       })
       .catch(() => {
         router.replace("/dashboard");
@@ -48,11 +54,41 @@ export default function GroupSettingsPage() {
   }, [groupId, router]);
 
   const refresh = async () => {
-    const g = await getGroup(groupId);
+    const [g, invs] = await Promise.all([getGroup(groupId), getInvitations(groupId)]);
     setGroup(g);
     setName(g.name);
     setColor(g.color);
     setIconUrl(g.iconUrl);
+    setInvitations(invs);
+  };
+
+  const handleCreateInvite = async () => {
+    try {
+      const inv = await createInvitation(groupId);
+      setNewInviteUrl(inv.url);
+      setInvitations((prev) => [inv, ...prev]);
+    } catch (e) {
+      toast.error(e instanceof ApiClientError ? e.message : "招待リンクの作成に失敗しました");
+    }
+  };
+
+  const handleCopyInvite = (url: string) => {
+    navigator.clipboard.writeText(url).then(() => toast.success("コピーしました"));
+  };
+
+  const handleRevoke = async (invitationId: string) => {
+    if (!confirm("この招待リンクを無効化しますか？")) return;
+    try {
+      await revokeInvitation(groupId, invitationId);
+      toast.success("招待リンクを無効化しました");
+      setInvitations((prev) => prev.filter((inv) => inv.id !== invitationId));
+      if (newInviteUrl) {
+        const revoked = invitations.find((inv) => inv.id === invitationId);
+        if (revoked && newInviteUrl === revoked.url) setNewInviteUrl(null);
+      }
+    } catch (e) {
+      toast.error(e instanceof ApiClientError ? e.message : "招待リンクの無効化に失敗しました");
+    }
   };
 
   const handleIconChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -185,18 +221,87 @@ export default function GroupSettingsPage() {
           保存
         </PrimaryButton>
 
-        <div className="border-t border-[#e5e0d8] dark:border-[#333230] pt-5">
-          <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1] mb-2">
+        <div className="border-t border-[#e5e0d8] dark:border-[#333230] pt-5 flex flex-col gap-4">
+          <h2 className="text-lg font-bold text-[#2d2a26] dark:text-[#eae7e1]">
             メンバー招待
           </h2>
-          <TextInput
-            label="メールアドレス"
-            type="email"
-            value={inviteEmail}
-            onChange={setInviteEmail}
-            placeholder="example@mail.com"
-          />
-          <div className="mt-3">
+
+          {/* 招待リンク */}
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-[#7a756d] dark:text-[#9e9a93]">
+              招待リンクを作成してシェアすると、リンクを受け取った人がグループに参加できます。
+            </p>
+            <PrimaryButton onClick={handleCreateInvite}>
+              招待リンクを作成
+            </PrimaryButton>
+            {newInviteUrl && (
+              <div className="flex items-center gap-2 rounded-xl border border-[#e5e0d8] dark:border-[#333230] p-3">
+                <span className="flex-1 text-xs text-[#4a4540] dark:text-[#c5c0b8] truncate">
+                  {newInviteUrl}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleCopyInvite(newInviteUrl)}
+                  className="shrink-0 px-3 py-1 rounded-lg text-xs font-semibold text-white bg-[#c9a227]"
+                >
+                  コピー
+                </button>
+              </div>
+            )}
+            {invitations.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <p className="text-xs font-medium text-[#7a756d] dark:text-[#9e9a93]">
+                  有効な招待リンク
+                </p>
+                {invitations.map((inv) => (
+                  <div
+                    key={inv.id}
+                    className="flex items-center justify-between rounded-xl border border-[#e5e0d8] dark:border-[#333230] p-3 gap-2"
+                  >
+                    <div className="flex flex-col min-w-0">
+                      <span className="text-xs text-[#4a4540] dark:text-[#c5c0b8] truncate">
+                        {inv.url}
+                      </span>
+                      {inv.expiresAt && (
+                        <span className="text-xs text-[#7a756d] dark:text-[#9e9a93]">
+                          {new Date(inv.expiresAt).toLocaleDateString("ja-JP")} まで有効
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex gap-2 shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => handleCopyInvite(inv.url)}
+                        className="px-2 py-1 rounded-lg text-xs font-semibold border border-[#e5e0d8] dark:border-[#333230]"
+                      >
+                        コピー
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRevoke(inv.id)}
+                        className="text-xs text-red-500 underline"
+                      >
+                        無効化
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* メールアドレスで直接追加 */}
+          <div className="flex flex-col gap-3">
+            <p className="text-sm font-medium text-[#4a4540] dark:text-[#c5c0b8]">
+              メールアドレスで直接追加
+            </p>
+            <TextInput
+              label="メールアドレス"
+              type="email"
+              value={inviteEmail}
+              onChange={setInviteEmail}
+              placeholder="example@mail.com"
+            />
             <PrimaryButton onClick={handleInvite}>追加する</PrimaryButton>
           </div>
         </div>

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import toast from "react-hot-toast";
+import ScreenContainer from "@/components/layout/ScreenContainer";
+import PageTransition from "@/components/layout/PageTransition";
+import GroupAvatar from "@/components/ui/GroupAvatar";
+import PrimaryButton from "@/components/ui/PrimaryButton";
+import type { InvitationInfo } from "@/types";
+import { ApiClientError, acceptInvitation, getInvitationInfo, isAuthenticated } from "@/lib/apiClient";
+
+type PageState = "loading" | "valid" | "invalid" | "expired" | "joined";
+
+export default function InvitePage() {
+  const router = useRouter();
+  const params = useParams<{ token: string }>();
+  const token = params.token;
+
+  const [state, setState] = useState<PageState>("loading");
+  const [info, setInfo] = useState<InvitationInfo | null>(null);
+  const [joining, setJoining] = useState(false);
+
+  useEffect(() => {
+    getInvitationInfo(token)
+      .then((data) => {
+        setInfo(data);
+        setState("valid");
+      })
+      .catch((e) => {
+        if (e instanceof ApiClientError && e.status === 410) {
+          setState("expired");
+        } else {
+          setState("invalid");
+        }
+      });
+  }, [token]);
+
+  const handleJoin = async () => {
+    if (!isAuthenticated()) {
+      router.push(`/login?redirect=/invite/${token}`);
+      return;
+    }
+    setJoining(true);
+    try {
+      const result = await acceptInvitation(token);
+      toast.success(`「${result.groupName}」に参加しました`);
+      router.push("/dashboard");
+    } catch (e) {
+      if (e instanceof ApiClientError && e.status === 401) {
+        router.push(`/login?redirect=/invite/${token}`);
+      } else {
+        toast.error(e instanceof ApiClientError ? e.message : "参加に失敗しました");
+      }
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  return (
+    <ScreenContainer>
+      <PageTransition className="flex flex-col items-center w-full gap-6 py-12 px-4">
+        {state === "loading" && (
+          <p className="text-[#7a756d] dark:text-[#9e9a93]">読み込み中...</p>
+        )}
+
+        {(state === "invalid" || state === "expired") && (
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="text-4xl">{state === "expired" ? "⏰" : "🚫"}</div>
+            <h1 className="text-xl font-bold text-[#2d2a26] dark:text-[#eae7e1]">
+              {state === "expired"
+                ? "招待リンクの有効期限が切れています"
+                : "無効な招待リンクです"}
+            </h1>
+            <p className="text-sm text-[#7a756d] dark:text-[#9e9a93]">
+              グループのオーナーに新しい招待リンクを発行してもらってください。
+            </p>
+            <Link
+              href="/dashboard"
+              className="text-sm underline text-[#c9a227]"
+            >
+              ダッシュボードへ
+            </Link>
+          </div>
+        )}
+
+        {state === "valid" && info && (
+          <div className="flex flex-col items-center gap-6 w-full max-w-sm">
+            <GroupAvatar
+              name={info.groupName}
+              color={info.groupColor}
+              iconUrl={info.groupIconUrl}
+              size={80}
+            />
+            <div className="text-center">
+              <p className="text-sm text-[#7a756d] dark:text-[#9e9a93] mb-1">
+                グループへの招待
+              </p>
+              <h1 className="text-2xl font-bold text-[#2d2a26] dark:text-[#eae7e1]">
+                {info.groupName}
+              </h1>
+              <p className="text-sm text-[#7a756d] dark:text-[#9e9a93] mt-1">
+                メンバー {info.memberCount} 人 ・ {info.createdByName} が招待
+              </p>
+              {info.expiresAt && (
+                <p className="text-xs text-[#7a756d] dark:text-[#9e9a93] mt-1">
+                  {new Date(info.expiresAt).toLocaleDateString("ja-JP")} まで有効
+                </p>
+              )}
+            </div>
+
+            <div className="w-full flex flex-col gap-3">
+              {isAuthenticated() ? (
+                <PrimaryButton onClick={handleJoin} loading={joining}>
+                  このグループに参加する
+                </PrimaryButton>
+              ) : (
+                <>
+                  <PrimaryButton onClick={handleJoin} loading={joining}>
+                    ログインして参加する
+                  </PrimaryButton>
+                  <p className="text-center text-xs text-[#7a756d] dark:text-[#9e9a93]">
+                    アカウントをお持ちでない方は{" "}
+                    <Link
+                      href={`/register?redirect=/invite/${token}`}
+                      className="underline text-[#c9a227]"
+                    >
+                      新規登録
+                    </Link>
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </PageTransition>
+    </ScreenContainer>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import toast from "react-hot-toast";
 import ScreenContainer from "@/components/layout/ScreenContainer";
 import PageTransition from "@/components/layout/PageTransition";
@@ -12,8 +12,9 @@ import PrimaryButton from "@/components/ui/PrimaryButton";
 import CoinIcon from "@/components/ui/CoinIcon";
 import { login, ApiClientError } from "@/lib/apiClient";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -36,7 +37,8 @@ export default function LoginPage() {
     try {
       await login(email, password);
       toast.success("ログインしました");
-      router.push("/dashboard");
+      const redirect = searchParams.get("redirect");
+      router.push(redirect ?? "/dashboard");
     } catch (e) {
       if (e instanceof ApiClientError) {
         toast.error(e.message);
@@ -49,55 +51,61 @@ export default function LoginPage() {
   };
 
   return (
+    <div className="flex flex-col gap-5 w-full flex-1">
+      <TextInput
+        label="メールアドレス"
+        type="text"
+        placeholder="example@example.com"
+        value={email}
+        onChange={(v) => {
+          setEmail(v);
+          if (errors.email) setErrors((e) => ({ ...e, email: undefined }));
+        }}
+        error={errors.email}
+      />
+      <TextInput
+        label="パスワード"
+        type="password"
+        placeholder="パスワードを入力"
+        value={password}
+        onChange={(v) => {
+          setPassword(v);
+          if (errors.password)
+            setErrors((e) => ({ ...e, password: undefined }));
+        }}
+        error={errors.password}
+      />
+
+      <div className="pt-2">
+        <PrimaryButton onClick={handleLogin} loading={loading}>
+          ログイン
+        </PrimaryButton>
+      </div>
+
+      <p className="text-center text-base text-[#7a756d] dark:text-[#9e9a93] mt-1">
+        <Link
+          href="/register"
+          className="underline hover:text-[#2d2a26] dark:hover:text-[#eae7e1] transition-colors duration-150"
+          aria-label="新規登録画面へ"
+        >
+          新規登録はこちら
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
     <ScreenContainer>
       <PageTransition className="flex flex-col items-center w-full flex-1">
-        {/* ロゴ */}
         <div className="pt-4 pb-8">
           <Logo size={100} showScriptText={true} />
         </div>
 
-        {/* フォーム */}
-        <div className="flex flex-col gap-5 w-full flex-1">
-          <TextInput
-            label="メールアドレス"
-            type="text"
-            placeholder="example@example.com"
-            value={email}
-            onChange={(v) => {
-              setEmail(v);
-              if (errors.email) setErrors((e) => ({ ...e, email: undefined }));
-            }}
-            error={errors.email}
-          />
-          <TextInput
-            label="パスワード"
-            type="password"
-            placeholder="パスワードを入力"
-            value={password}
-            onChange={(v) => {
-              setPassword(v);
-              if (errors.password)
-                setErrors((e) => ({ ...e, password: undefined }));
-            }}
-            error={errors.password}
-          />
-
-          <div className="pt-2">
-            <PrimaryButton onClick={handleLogin} loading={loading}>
-              ログイン
-            </PrimaryButton>
-          </div>
-
-          <p className="text-center text-base text-[#7a756d] dark:text-[#9e9a93] mt-1">
-            <Link
-              href="/register"
-              className="underline hover:text-[#2d2a26] dark:hover:text-[#eae7e1] transition-colors duration-150"
-              aria-label="新規登録画面へ"
-            >
-              新規登録はこちら
-            </Link>
-          </p>
-        </div>
+        <Suspense fallback={<div className="flex-1" />}>
+          <LoginForm />
+        </Suspense>
 
         <footer className="py-4 flex justify-center mt-auto">
           <CoinIcon size="md" />

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import toast from "react-hot-toast";
 import ScreenContainer from "@/components/layout/ScreenContainer";
 import PageTransition from "@/components/layout/PageTransition";
@@ -12,8 +12,9 @@ import PrimaryButton from "@/components/ui/PrimaryButton";
 import CoinIcon from "@/components/ui/CoinIcon";
 import { register, ApiClientError } from "@/lib/apiClient";
 
-export default function RegisterPage() {
+function RegisterForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -40,7 +41,8 @@ export default function RegisterPage() {
     try {
       await register(name, email, password);
       toast.success("登録が完了しました。ログインしてください。");
-      router.push("/login");
+      const redirect = searchParams.get("redirect");
+      router.push(redirect ? `/login?redirect=${encodeURIComponent(redirect)}` : "/login");
     } catch (e) {
       if (e instanceof ApiClientError) {
         toast.error(e.message);
@@ -53,66 +55,72 @@ export default function RegisterPage() {
   };
 
   return (
+    <div className="flex flex-col gap-5 w-full flex-1">
+      <TextInput
+        label="名前"
+        type="text"
+        placeholder="名前を入力"
+        value={name}
+        onChange={(v) => {
+          setName(v);
+          if (errors.name) setErrors((e) => ({ ...e, name: undefined }));
+        }}
+        error={errors.name}
+      />
+      <TextInput
+        label="メールアドレス"
+        type="text"
+        placeholder="example@example.com"
+        value={email}
+        onChange={(v) => {
+          setEmail(v);
+          if (errors.email) setErrors((e) => ({ ...e, email: undefined }));
+        }}
+        error={errors.email}
+      />
+      <TextInput
+        label="パスワード"
+        type="password"
+        placeholder="パスワードを入力"
+        value={password}
+        onChange={(v) => {
+          setPassword(v);
+          if (errors.password)
+            setErrors((e) => ({ ...e, password: undefined }));
+        }}
+        error={errors.password}
+      />
+
+      <div className="pt-2">
+        <PrimaryButton onClick={handleRegister} loading={loading}>
+          新規登録
+        </PrimaryButton>
+      </div>
+
+      <p className="text-center text-base text-[#7a756d] dark:text-[#9e9a93] mt-1">
+        <Link
+          href="/login"
+          className="underline hover:text-[#2d2a26] dark:hover:text-[#eae7e1] transition-colors duration-150"
+          aria-label="ログイン画面へ"
+        >
+          ログインはこちら
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+export default function RegisterPage() {
+  return (
     <ScreenContainer>
       <PageTransition className="flex flex-col items-center w-full flex-1">
-        {/* ロゴ */}
         <div className="pt-4 pb-8">
           <Logo size={100} showScriptText={true} />
         </div>
 
-        {/* フォーム */}
-        <div className="flex flex-col gap-5 w-full flex-1">
-          <TextInput
-            label="名前"
-            type="text"
-            placeholder="名前を入力"
-            value={name}
-            onChange={(v) => {
-              setName(v);
-              if (errors.name) setErrors((e) => ({ ...e, name: undefined }));
-            }}
-            error={errors.name}
-          />
-          <TextInput
-            label="メールアドレス"
-            type="text"
-            placeholder="example@example.com"
-            value={email}
-            onChange={(v) => {
-              setEmail(v);
-              if (errors.email) setErrors((e) => ({ ...e, email: undefined }));
-            }}
-            error={errors.email}
-          />
-          <TextInput
-            label="パスワード"
-            type="password"
-            placeholder="パスワードを入力"
-            value={password}
-            onChange={(v) => {
-              setPassword(v);
-              if (errors.password)
-                setErrors((e) => ({ ...e, password: undefined }));
-            }}
-            error={errors.password}
-          />
-
-          <div className="pt-2">
-            <PrimaryButton onClick={handleRegister} loading={loading}>
-              新規登録
-            </PrimaryButton>
-          </div>
-
-          <p className="text-center text-base text-[#7a756d] dark:text-[#9e9a93] mt-1">
-            <Link
-              href="/login"
-              className="underline hover:text-[#2d2a26] dark:hover:text-[#eae7e1] transition-colors duration-150"
-              aria-label="ログイン画面へ"
-            >
-              ログインはこちら
-            </Link>
-          </p>
-        </div>
+        <Suspense fallback={<div className="flex-1" />}>
+          <RegisterForm />
+        </Suspense>
 
         <footer className="py-4 flex justify-center mt-auto">
           <CoinIcon size="md" />

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -10,6 +10,8 @@ import type {
   RegisterResponse,
   UserProfile,
   Group,
+  GroupInvitation,
+  InvitationInfo,
   ExpenseRecord,
   CategoryName,
   ExpenseShare,
@@ -292,6 +294,45 @@ export async function deleteExpense(
 
 export async function getSettlement(groupId: string): Promise<SettlementResult> {
   return apiFetch<SettlementResult>(`/api/groups/${groupId}/settlement`);
+}
+
+/* ========== 招待リンク API ========== */
+
+export async function createInvitation(
+  groupId: string,
+  expiresInDays = 7
+): Promise<GroupInvitation> {
+  return apiFetch<GroupInvitation>(`/api/groups/${groupId}/invitations`, {
+    method: "POST",
+    body: JSON.stringify({ expiresInDays }),
+  });
+}
+
+export async function getInvitations(groupId: string): Promise<GroupInvitation[]> {
+  return apiFetch<GroupInvitation[]>(`/api/groups/${groupId}/invitations`);
+}
+
+export async function revokeInvitation(
+  groupId: string,
+  invitationId: string
+): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(
+    `/api/groups/${groupId}/invitations/${invitationId}`,
+    { method: "DELETE" }
+  );
+}
+
+export async function getInvitationInfo(token: string): Promise<InvitationInfo> {
+  return apiFetch<InvitationInfo>(`/api/invite/${token}`);
+}
+
+export async function acceptInvitation(
+  token: string
+): Promise<{ groupId: string; groupName: string }> {
+  return apiFetch<{ groupId: string; groupName: string }>(
+    `/api/invite/${token}/accept`,
+    { method: "POST" }
+  );
 }
 
 export { ApiClientError };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -134,6 +134,25 @@ export type SettlementResult = {
   expenseCount: number;
 };
 
+export type GroupInvitation = {
+  id: string;
+  token: string;
+  url: string;
+  expiresAt: string | null;
+  createdAt: string;
+  status: "ACTIVE" | "REVOKED";
+};
+
+export type InvitationInfo = {
+  groupId: string;
+  groupName: string;
+  groupColor: string;
+  groupIconUrl?: string;
+  memberCount: number;
+  createdByName: string;
+  expiresAt: string | null;
+};
+
 export type DashboardSummary = {
   totalPersonalAmount: number;
   previousMonthTotalPersonalAmount: number;


### PR DESCRIPTION
## 概要

招待リンク（URL）方式によるメンバー招待機能を実装。OWNER/ADMIN が招待URLを生成してLINE等でシェアし、受け取った人がグループに参加できる。

Closes #12

## 変更内容

- `GroupInvitation` モデル追加（DBマイグレーション済み）
- 招待リンク作成・一覧・無効化 API を追加（`/api/groups/[groupId]/invitations`）
- 招待情報取得・承諾 API を追加（`/api/invite/[token]`, `/api/invite/[token]/accept`）
- `/invite/[token]` 招待ランディングページを新規追加
- グループ設定ページに招待リンク作成・コピー・無効化 UI を追加
- ログイン・登録ページに `?redirect=` 対応を追加（招待URL経由でのリダイレクトに対応）

## 背景・理由

既存の「メールアドレスで直接追加」方式では、招待される側がアプリ登録済みである必要があり、通知もなく同意フローもなかった。招待リンク方式にすることで、未登録ユーザーも招待でき、LINEなどで気軽にシェアできるようになる。

## 技術的な判断

**招待リンク方式を選択した理由:**
- `crypto.randomBytes(16).toString("hex")` で生成した推測不可能なトークンをURLに埋め込む方式を採用
- 招待情報取得（`GET /api/invite/[token]`）は認証不要にしてランディングページでグループ情報を表示できるようにした
- 承諾（`POST accept`）は既にメンバーなら 200 を返す冪等設計にし、二重参加を防ぐ
- 既存のメールアドレス直接追加UIは削除せず併存させた

## 動作確認

- [ ] ローカルで動作確認済み
- [ ] 既存機能に影響がないことを確認

**確認フロー:**
1. グループ設定 → 「招待リンクを作成」→ URL表示・コピー確認
2. 未ログイン状態でURL → ログインページへリダイレクト → ログイン後に招待ページへ戻ることを確認
3. 「参加する」→ グループメンバー一覧に追加されることを確認
4. 「無効化」→ そのURLへアクセスするとエラーになることを確認
5. 新規登録ページからの招待フローも確認